### PR TITLE
number pressed only one command, equals takes mode now

### DIFF
--- a/src/CalcEngineString.java
+++ b/src/CalcEngineString.java
@@ -26,7 +26,7 @@ public class CalcEngineString {
      * Calculate the dec / hex output
      * @param number The number pressed on the calculator.
      */
-	public void numberPressed(int number, int mode) {
+	public void numberPressed(String number) {
         displayString = displayString + number; 
     }
 
@@ -34,10 +34,15 @@ public class CalcEngineString {
     	displayString = displayString + command;
     }
 	 
-	public void equals() throws StackUnderflowException, IncorrectFormatException {
+	public void equals(int mode) throws StackUnderflowException, IncorrectFormatException {
     	if (displayString != null) {
     		String pfx = postfix.infixToPostfix(displayString);
-        	displayString = ""+postfix.evaluate(pfx);
+    		if (mode == 10) {
+    			displayString = ""+postfix.evaluate(pfx);
+    		} else {
+    			//Cast Doubles to integer, as hex cant calculate doubles anyways!
+    			displayString = ""+ Integer.toHexString((int) (postfix.evaluate(pfx)));
+    		}
     	}
     }
 	


### PR DESCRIPTION
Mode is not needed in number pressed, as it only now passes strings.
But mode is now part of the equals method, as depending on the mode, it needs to convert the display string accordingly while the result remains a number internally.