### PR TITLE
Added hexadecimal evaluation to postfix

### DIFF
--- a/src/Postfix.java
+++ b/src/Postfix.java
@@ -32,6 +32,10 @@ public class Postfix {
 			//t is an operand -> push it to operands stack
 			if(Character.isDigit(t)) {
 				operands.push((double)(Character.getNumericValue(t))); //only works for digits 0-9 
+				
+			}else if(Character.isAlphabetic(t)) {
+				double x = Integer.parseInt(""+ t, 16);
+				operands.push(x);
 			//t is whitespace -> do nothing, move on to next character
 			}else if (t == ' '){
 				


### PR DESCRIPTION
The evaluation needs to deal with letters now, parsing them to numbers with base 16 before pushing them to stack.
without this or if it is done before, each digit would be treated as a single unit... and A-F are multi digit numbers, which our calculator can't handle!