### PR TITLE
More tests, that make the calculator fail

### DIFF
--- a/src/CalculatorTest.java
+++ b/src/CalculatorTest.java
@@ -24,7 +24,7 @@ class CalculatorTest {
 	}
 
 	@Test 
-	void test1() throws StackUnderflowException, IncorrectFormatException {
+	void test01() throws StackUnderflowException, IncorrectFormatException {
 		engine.buttonPressed("5");
 		engine.buttonPressed("+");
 		engine.buttonPressed("5");
@@ -33,7 +33,7 @@ class CalculatorTest {
 	}
 	
 	@Test 
-	void test2() throws StackUnderflowException, IncorrectFormatException  {
+	void test02() throws StackUnderflowException, IncorrectFormatException  {
 		engine.buttonPressed("1");
 		engine.buttonPressed("+");
 		engine.buttonPressed("2");
@@ -44,7 +44,18 @@ class CalculatorTest {
 	}
 	
 	@Test 
-	void test3() throws StackUnderflowException, IncorrectFormatException  {
+	void test03() throws StackUnderflowException, IncorrectFormatException  {
+		engine.buttonPressed("1");
+		engine.buttonPressed("*");
+		engine.buttonPressed("2");
+		engine.buttonPressed("+");
+		engine.buttonPressed("3");
+		engine.equals(10);
+		assertEquals("5.0", engine.getDisplayString());
+	}
+	
+	@Test 
+	void test04() throws StackUnderflowException, IncorrectFormatException  {
 		engine.buttonPressed("(");
 		engine.buttonPressed("1");
 		engine.buttonPressed("+");
@@ -57,7 +68,7 @@ class CalculatorTest {
 	}
 	
 	@Test 
-	void test4() throws StackUnderflowException, IncorrectFormatException  {
+	void test05() throws StackUnderflowException, IncorrectFormatException  {
 		engine.buttonPressed("1");
 		engine.buttonPressed("+");
 		engine.buttonPressed("2");
@@ -72,7 +83,7 @@ class CalculatorTest {
 	}
 	
 	@Test 
-	void test5() throws StackUnderflowException, IncorrectFormatException  {
+	void test06() throws StackUnderflowException, IncorrectFormatException  {
 		engine.buttonPressed("1");
 		engine.buttonPressed("*");
 		engine.buttonPressed("2");
@@ -87,22 +98,7 @@ class CalculatorTest {
 	}
 	
 	@Test 
-	void test6() throws StackUnderflowException, IncorrectFormatException  {
-		engine.buttonPressed("1");
-		engine.buttonPressed("*");
-		engine.buttonPressed("(");
-		engine.buttonPressed("2");
-		engine.buttonPressed("+");
-		engine.buttonPressed("3");
-		engine.buttonPressed(")");
-		engine.buttonPressed("+");
-		engine.buttonPressed("4");
-		engine.equals(10);
-		assertEquals("9.0", engine.getDisplayString());
-	}
-	
-	@Test 
-	void test7() throws StackUnderflowException, IncorrectFormatException  {
+	void test07() throws StackUnderflowException, IncorrectFormatException  {
 		engine.buttonPressed("(");
 		engine.buttonPressed("1");
 		engine.buttonPressed("+");
@@ -119,7 +115,7 @@ class CalculatorTest {
 	}
 	
 	@Test 
-	void test8() throws StackUnderflowException, IncorrectFormatException  {
+	void test08() throws StackUnderflowException, IncorrectFormatException  {
 		engine.buttonPressed("1");
 		engine.buttonPressed("+");
 		engine.buttonPressed("2");
@@ -132,7 +128,7 @@ class CalculatorTest {
 	}
 	
 	@Test 
-	void test9() throws StackUnderflowException, IncorrectFormatException  {
+	void test09() throws StackUnderflowException, IncorrectFormatException  {
 		engine.buttonPressed("1");
 		engine.buttonPressed("*");
 		engine.buttonPressed("2");
@@ -146,18 +142,104 @@ class CalculatorTest {
 	
 	@Test 
 	void test10() throws StackUnderflowException, IncorrectFormatException  {
-//		engine.buttonPressed("(");
-//		engine.buttonPressed("1");
-//		engine.buttonPressed("+");
-//		engine.buttonPressed("2");
-//		engine.buttonPressed(")");
-//		engine.buttonPressed("*");
-//		engine.buttonPressed("(");
-//		engine.buttonPressed("3");
-//		engine.buttonPressed("+");
-//		engine.buttonPressed("4");
-//		engine.buttonPressed(")");
+		engine.buttonPressed("1");
+		engine.buttonPressed("*");
+		engine.buttonPressed("(");
+		engine.buttonPressed("2");
+		engine.buttonPressed("+");
+		engine.buttonPressed("3");
+		engine.buttonPressed(")");
+		engine.buttonPressed("+");
+		engine.buttonPressed("4");
 		engine.equals(10);
-		assertEquals("21.0", engine.getDisplayString());
+		assertEquals("9.0", engine.getDisplayString());
+	}
+	
+	@Test 
+	void test11() throws StackUnderflowException, IncorrectFormatException  {
+		engine.buttonPressed("1");
+		engine.buttonPressed("*");
+		engine.buttonPressed("2");
+		engine.buttonPressed("*");
+		engine.buttonPressed("3");
+		engine.buttonPressed("+");
+		engine.buttonPressed("4");
+		engine.buttonPressed("+");
+		engine.buttonPressed("5");
+		engine.equals(10);
+		assertEquals("15.0", engine.getDisplayString());
+	}
+	// The following tests fail, indicating not correct calculated precedence
+	// when same operators of high precedence follow each other!
+	@Test 
+	void test12() throws StackUnderflowException, IncorrectFormatException  {
+		engine.buttonPressed("1");
+		engine.buttonPressed("+");
+		engine.buttonPressed("2");
+		engine.buttonPressed("+");
+		engine.buttonPressed("3");
+		engine.buttonPressed("*");
+		engine.buttonPressed("4");
+		engine.buttonPressed("*");
+		engine.buttonPressed("5");
+		engine.equals(10); //Expected result 63, returns 75!
+		assertEquals("63.0", engine.getDisplayString());
+	}
+	
+	@Test 
+	void test13() throws StackUnderflowException, IncorrectFormatException  {
+		engine.buttonPressed("1");
+		engine.buttonPressed("+");
+		engine.buttonPressed("2");
+		engine.buttonPressed("+");
+		engine.buttonPressed("3");
+		engine.buttonPressed("*");
+		engine.buttonPressed("4");
+		engine.buttonPressed("*");
+		engine.buttonPressed("5");
+		engine.buttonPressed("+");
+		engine.buttonPressed("6");
+		engine.buttonPressed("+");
+		engine.buttonPressed("7");
+		engine.equals(10); //Expected result 76, returns 88!
+		assertEquals("76.0", engine.getDisplayString());
+	}
+	
+	@Test 
+	void test14() throws StackUnderflowException, IncorrectFormatException  {
+		engine.buttonPressed("1");
+		engine.buttonPressed("*");
+		engine.buttonPressed("2");
+		engine.buttonPressed("*");
+		engine.buttonPressed("3");
+		engine.buttonPressed("+");
+		engine.buttonPressed("4");
+		engine.buttonPressed("+");
+		engine.buttonPressed("5");
+		engine.buttonPressed("*");
+		engine.buttonPressed("6");
+		engine.buttonPressed("*");
+		engine.buttonPressed("7");
+		engine.equals(10); //Expected result 72, returns 75!
+		assertEquals("220.0", engine.getDisplayString());
+	}
+	
+	@Test 
+	void test15() throws StackUnderflowException, IncorrectFormatException  {
+		engine.buttonPressed("1");
+		engine.buttonPressed("+");
+		engine.buttonPressed("2");
+		engine.buttonPressed("*");
+		engine.buttonPressed("3");
+		engine.buttonPressed("*");
+		engine.buttonPressed("4");
+		engine.buttonPressed("+");
+		engine.buttonPressed("5");
+		engine.buttonPressed("+");
+		engine.buttonPressed("6");
+		engine.buttonPressed("*");
+		engine.buttonPressed("7");
+		engine.equals(10); //Expected result 72, returns 75!
+		assertEquals("72.0", engine.getDisplayString());
 	}
 }


### PR DESCRIPTION
Seems like the precedence evaluation doesn't work right. If multiple numbers of higher precedence operators follow lower ones, or are mixed together, the postfix string isn't created correctly, as for that it can't be evaluated correctly.